### PR TITLE
Garante que Política de Privacidade foi aceita antes de submeter formulário

### DIFF
--- a/app/components/AboutYouForm.js
+++ b/app/components/AboutYouForm.js
@@ -139,7 +139,7 @@ export class AboutYouForm extends Component {
           value={this.state.acceptedPolicies}
           label="Ao registrar esse relato eu concordo com a Política de Privacidade do Eu Também."
         />
-        <ErrorMessage visible={triedSubmit && !this.state.formData.skinColor.valid}>
+        <ErrorMessage visible={triedSubmit && !this.state.formData.acceptedPolicies}>
           Por favor, leia e aceite nossa Política de Privacidade
         </ErrorMessage>
         <Text style={appStyles.link} onPress={() => this.props.navigation.navigate('PrivacyPolicy')}>

--- a/app/components/AboutYouForm.js
+++ b/app/components/AboutYouForm.js
@@ -2,10 +2,11 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { View, Text } from 'react-native';
 
-import appStyles, { RED } from '../styles';
+import appStyles from '../styles';
 
 import { Button, CheckBox, Picker, TextInput, SectionHeader, SectionText } from './common';
 import { formWrapper, loading } from './hoc';
+import ErrorMessage from './ErrorMessage';
 
 export class AboutYouForm extends Component {
   constructor(props) {
@@ -21,9 +22,15 @@ export class AboutYouForm extends Component {
         sexualOrientation: { value: '', valid: true },
       },
       acceptedPolicies: false,
-      containErrors: false,
+      triedSubmit: false,
     };
   }
+
+  getThisFormDataValues = () => Object.entries(this.state.formData)
+    .reduce((formDataValues, [key, { value }]) => ({
+      ...formDataValues,
+      [key]: value,
+    }), {});
 
   updateFormDataValue = (key, value, valid) => {
     const { formData } = this.state;
@@ -35,36 +42,25 @@ export class AboutYouForm extends Component {
     }
   };
 
-  getThisFormDataValues = () => {
-    const formDataValues = {};
-    Object.keys(this.state.formData).forEach(key => { formDataValues[key] = this.state.formData[key].value; });
-    return formDataValues;
-  };
-
   formData = () => ({
     ...this.props.navigation.getParam('formData', {}),
     ...this.getThisFormDataValues(),
   });
 
-  isValid = () => {
-    return Object.values(this.state.formData).reduce((valid, currentData) => valid && currentData.valid, true);
-  };
+  isValid = () => this.state.acceptedPolicies
+    && Object.values(this.state.formData).every(field => field.valid);
 
   submit = () => {
     if (this.isValid()) {
-      this.setState({ containErrors: false });
-      this.props.navigation.navigate('SendReport', { formData: this.formData() })
+      this.setState({ triedSubmit: false });
+      this.props.navigation.navigate('SendReport', { formData: this.formData() });
     } else {
-      this.setState({ containErrors: true });
+      this.setState({ triedSubmit: true });
     }
   };
 
   render() {
-    const validationMessage = (
-      <Text style={{ color: RED }}>
-        Sentimos falta de algumas informações obrigatórias. Por favor, preencha-as e tente novamente.
-      </Text>
-    );
+    const { triedSubmit } = this.state;
 
     return (
       <View>
@@ -72,24 +68,30 @@ export class AboutYouForm extends Component {
           required
           testID="gender-input"
           placeholder="Gênero"
-          showValidation={this.state.containErrors}
+          showValidation={this.state.triedSubmit}
           value={this.state.formData.gender.value}
           onValueChange={(value, valid) => this.updateFormDataValue('gender', value, valid)}
           items={this.props.data.formOptions.gender_options}
         />
+        <ErrorMessage visible={triedSubmit && !this.state.formData.gender.valid}>
+          Por favor, informe seu gênero
+        </ErrorMessage>
         <Picker
           required
           testID="skin-color-input"
           placeholder="Cor"
-          showValidation={this.state.containErrors}
+          showValidation={this.state.triedSubmit}
           value={this.state.formData.skinColor.value}
           onValueChange={(value, valid) => this.updateFormDataValue('skinColor', value, valid)}
           items={this.props.data.formOptions.skin_color_options}
         />
+        <ErrorMessage visible={triedSubmit && !this.state.formData.skinColor.valid}>
+          Por favor, informe sua cor
+        </ErrorMessage>
         <Picker
           testID="age-input"
           placeholder="Idade"
-          showValidation={this.state.containErrors}
+          showValidation={this.state.triedSubmit}
           value={this.state.formData.age.value}
           onValueChange={(value, valid) => this.updateFormDataValue('age', value, valid)}
           items={this.props.data.formOptions.age_options}
@@ -97,7 +99,7 @@ export class AboutYouForm extends Component {
         <Picker
           testID="orientation-input"
           placeholder="Orientação Sexual"
-          showValidation={this.state.containErrors}
+          showValidation={this.state.triedSubmit}
           value={this.state.formData.sexualOrientation.value}
           onValueChange={(value, valid) => this.updateFormDataValue('sexualOrientation', value, valid)}
           items={this.props.data.formOptions.sexual_orientation}
@@ -105,7 +107,7 @@ export class AboutYouForm extends Component {
         <Picker
           testID="wage-input"
           placeholder="Renda Aproximada"
-          showValidation={this.state.containErrors}
+          showValidation={this.state.triedSubmit}
           value={this.state.formData.wage.value}
           onValueChange={(value, valid) => this.updateFormDataValue('wage', value, valid)}
           items={this.props.data.formOptions.wage_options}
@@ -118,14 +120,17 @@ export class AboutYouForm extends Component {
           placeholder="Email"
           textContentType="emailAddress"
           keyboardType="email-address"
-          showValidation={this.state.containErrors}
+          showValidation={this.state.triedSubmit}
           onValueChange={(email, valid) => this.updateFormDataValue('email', email, valid)}
           value={this.state.formData.email.value}
         />
+        <ErrorMessage visible={triedSubmit && !this.state.formData.email.valid}>
+          Por favor, informe seu email
+        </ErrorMessage>
         <TextInput
           testID="name-input"
           placeholder="Nome"
-          showValidation={this.state.containErrors}
+          showValidation={this.state.triedSubmit}
           onValueChange={(name, valid) => this.updateFormDataValue('name', name, valid)}
           value={this.state.formData.name.value}
         />
@@ -134,10 +139,12 @@ export class AboutYouForm extends Component {
           value={this.state.acceptedPolicies}
           label="Ao registrar esse relato eu concordo com a Política de Privacidade do Eu Também."
         />
+        <ErrorMessage visible={triedSubmit && !this.state.formData.skinColor.valid}>
+          Por favor, leia e aceite nossa Política de Privacidade
+        </ErrorMessage>
         <Text style={appStyles.link} onPress={() => this.props.navigation.navigate('PrivacyPolicy')}>
           Acessar Política de Privacidade
         </Text>
-        { this.state.containErrors ? validationMessage : null }
         <Button
           testID="send-button"
           onPress={() => this.submit()}

--- a/app/components/AboutYouForm.js
+++ b/app/components/AboutYouForm.js
@@ -73,9 +73,6 @@ export class AboutYouForm extends Component {
           onValueChange={(value, valid) => this.updateFormDataValue('gender', value, valid)}
           items={this.props.data.formOptions.gender_options}
         />
-        <ErrorMessage visible={triedSubmit && !this.state.formData.gender.valid}>
-          Por favor, informe seu gênero
-        </ErrorMessage>
         <Picker
           required
           testID="skin-color-input"
@@ -85,9 +82,6 @@ export class AboutYouForm extends Component {
           onValueChange={(value, valid) => this.updateFormDataValue('skinColor', value, valid)}
           items={this.props.data.formOptions.skin_color_options}
         />
-        <ErrorMessage visible={triedSubmit && !this.state.formData.skinColor.valid}>
-          Por favor, informe sua cor
-        </ErrorMessage>
         <Picker
           testID="age-input"
           placeholder="Idade"
@@ -124,9 +118,6 @@ export class AboutYouForm extends Component {
           onValueChange={(email, valid) => this.updateFormDataValue('email', email, valid)}
           value={this.state.formData.email.value}
         />
-        <ErrorMessage visible={triedSubmit && !this.state.formData.email.valid}>
-          Por favor, informe seu email
-        </ErrorMessage>
         <TextInput
           testID="name-input"
           placeholder="Nome"
@@ -145,11 +136,12 @@ export class AboutYouForm extends Component {
         <Text style={appStyles.link} onPress={() => this.props.navigation.navigate('PrivacyPolicy')}>
           Acessar Política de Privacidade
         </Text>
-        <Button
-          testID="send-button"
-          onPress={() => this.submit()}
-          title="Prosseguir"
-        />
+        <ErrorMessage visbile={triedSubmit && !this.isValid()}>
+          Sentimos falta de algumas informações obrigatórias. Por favor, preencha-as e tente
+          novamente.
+        </ErrorMessage>
+
+        <Button testID="send-button" onPress={() => this.submit()} title="Prosseguir" />
       </View>
     );
   }

--- a/app/components/ErrorMessage.js
+++ b/app/components/ErrorMessage.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Text } from 'react-native';
+import PropTypes from 'prop-types';
+
+import { RED } from '../styles';
+
+export default function ErrorMessage({ visible, children }) {
+  if (!visible) return null;
+
+  return (
+    <Text style={{ color: RED }}>
+      {children}
+    </Text>
+  );
+}
+
+ErrorMessage.propTypes = {
+  visible: PropTypes.bool.isRequired,
+  children: PropTypes.node.isRequired,
+};

--- a/app/components/__tests__/AboutYouForm.test.js
+++ b/app/components/__tests__/AboutYouForm.test.js
@@ -132,7 +132,7 @@ describe('AboutYouForm', () => {
 
     beforeEach(() => {
       wrapper = shallow(<AboutYouForm {...props} />);
-    })
+    });
 
     it('gender change reflects the formData gender state attribute', () => {
       wrapper.find({ testID: 'gender-input' }).props().onValueChange('woman', true);
@@ -188,7 +188,7 @@ describe('AboutYouForm', () => {
     it('does not pass the form data values to the SendReport screen when at least one input is invalid', () => {
       props.navigation.navigate = sinon.spy();
       const wrapper = shallow(<AboutYouForm {...props} />);
-  
+
       const formData = {
         gender: { value: '', valid: false },
         skinColor: { value: 'black', valid: true },
@@ -198,17 +198,17 @@ describe('AboutYouForm', () => {
         name: { value: 'Marielle', valid: true },
         sexualOrientation: { value: 'other', valid: true },
       };
-  
+
       wrapper.setState({ formData });
       wrapper.find('Button').simulate('press');
 
       expect(props.navigation.navigate.callCount).toEqual(0);
     });
 
-    it('sets containErrors state of form and the showValidation prop of all inputs to true when at least one input is invalid', () => {
+    it("sets triedSubmit when tries to submit when there's at least one error", () => {
       props.navigation.navigate = sinon.spy();
       const wrapper = shallow(<AboutYouForm {...props} />);
-  
+
       const formData = {
         gender: { value: '', valid: false },
         skinColor: { value: 'black', valid: true },
@@ -218,11 +218,12 @@ describe('AboutYouForm', () => {
         name: { value: 'Marielle', valid: true },
         sexualOrientation: { value: 'other', valid: true },
       };
-  
+
       wrapper.setState({ formData });
+      wrapper.setState({ acceptedPolicies: true });
       wrapper.find('Button').simulate('press');
 
-      expect(wrapper.state('containErrors')).toBeTruthy();
+      expect(wrapper.state('triedSubmit')).toBeTruthy();
       expect(wrapper.find({ showValidation: true })).toHaveLength(7);
     });
 
@@ -238,7 +239,7 @@ describe('AboutYouForm', () => {
       };
 
       const wrapper = shallow(<AboutYouForm {...props} />);
-  
+
       const formData = {
         gender: { value: 'woman', valid: true },
         skinColor: { value: 'black', valid: true },
@@ -252,10 +253,11 @@ describe('AboutYouForm', () => {
       Object.keys(formData).forEach((key) => {
         formDataValues[key] = formData[key].value;
       });
-  
+
       wrapper.setState({ formData });
+      wrapper.setState({ acceptedPolicies: true });
       wrapper.find('Button').simulate('press');
-      
+
       expect(props.navigation.navigate.callCount).toEqual(1);
       expect(props.navigation.navigate.calledWith('SendReport', {
         formData: {


### PR DESCRIPTION
Aproveitei para refatorar alguns trechos de código nesse mesmo arquivo para seguir o eslint configurado no projeto.

Percebi também que existia apenas uma mensagem de erro, então quebrei ela para deixar a mensagem mais próxima do campo, que é um bom princípio de design de validação de formulários.

Se vocês preferirem a uma mensagem no final, eu posso fazer o rollback do componente `ErrorMessage` e retornar ao comportamento anterior.

closes #45 
